### PR TITLE
Add a top-level workspace to prepare for future dependencies

### DIFF
--- a/Bookmarks.xcworkspace/contents.xcworkspacedata
+++ b/Bookmarks.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:ios/Bookmarks.xcodeproj">
+      location = "group:/Users/jbmorley/Projects/bookmarks/ios/Bookmarks-iOS.xcodeproj">
    </FileRef>
 </Workspace>

--- a/Bookmarks.xcworkspace/contents.xcworkspacedata
+++ b/Bookmarks.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/jbmorley/Projects/bookmarks/ios/Bookmarks-iOS.xcodeproj">
+      location = "group:ios/Bookmarks-iOS.xcodeproj">
    </FileRef>
 </Workspace>

--- a/Bookmarks.xcworkspace/contents.xcworkspacedata
+++ b/Bookmarks.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:ios/Bookmarks.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Bookmarks.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Bookmarks.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Bookmarks.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bookmarks.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "Introspect",
+        "repositoryURL": "https://github.com/siteline/SwiftUI-Introspect.git",
+        "state": {
+          "branch": null,
+          "revision": "2e09be8af614401bc9f87d40093ec19ce56ccaf2",
+          "version": "0.1.3"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Bookmarks.xcworkspace/xcshareddata/xcschemes/Bookmarks iOS.xcscheme
+++ b/Bookmarks.xcworkspace/xcshareddata/xcschemes/Bookmarks iOS.xcscheme
@@ -17,7 +17,7 @@
                BlueprintIdentifier = "D8D3BBF521C6AEBC00D6FB97"
                BuildableName = "Bookmarks.app"
                BlueprintName = "Bookmarks"
-               ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
+               ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -35,7 +35,7 @@
                BlueprintIdentifier = "D8D3BC0921C6AEBD00D6FB97"
                BuildableName = "BookmarksTests.xctest"
                BlueprintName = "BookmarksTests"
-               ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
+               ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
@@ -45,7 +45,7 @@
                BlueprintIdentifier = "D8D3BC1421C6AEBD00D6FB97"
                BuildableName = "BookmarksUITests.xctest"
                BlueprintName = "BookmarksUITests"
-               ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
+               ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -67,7 +67,7 @@
             BlueprintIdentifier = "D8D3BBF521C6AEBC00D6FB97"
             BuildableName = "Bookmarks.app"
             BlueprintName = "Bookmarks"
-            ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
+            ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
@@ -84,7 +84,7 @@
             BlueprintIdentifier = "D8D3BBF521C6AEBC00D6FB97"
             BuildableName = "Bookmarks.app"
             BlueprintName = "Bookmarks"
-            ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
+            ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
+++ b/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 					};
 				};
 			};
-			buildConfigurationList = D8D3BBF121C6AEBC00D6FB97 /* Build configuration list for PBXProject "Bookmarks" */;
+			buildConfigurationList = D8D3BBF121C6AEBC00D6FB97 /* Build configuration list for PBXProject "Bookmarks-iOS" */;
 			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -736,7 +736,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		D8D3BBF121C6AEBC00D6FB97 /* Build configuration list for PBXProject "Bookmarks" */ = {
+		D8D3BBF121C6AEBC00D6FB97 /* Build configuration list for PBXProject "Bookmarks-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D8D3BC1C21C6AEBD00D6FB97 /* Debug */,

--- a/ios/Bookmarks-iOS.xcodeproj/xcshareddata/xcschemes/Bookmarks iOS.xcscheme
+++ b/ios/Bookmarks-iOS.xcodeproj/xcshareddata/xcschemes/Bookmarks iOS.xcscheme
@@ -17,7 +17,7 @@
                BlueprintIdentifier = "D8D3BBF521C6AEBC00D6FB97"
                BuildableName = "Bookmarks.app"
                BlueprintName = "Bookmarks"
-               ReferencedContainer = "container:Bookmarks.xcodeproj">
+               ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -35,7 +35,7 @@
                BlueprintIdentifier = "D8D3BC0921C6AEBD00D6FB97"
                BuildableName = "BookmarksTests.xctest"
                BlueprintName = "BookmarksTests"
-               ReferencedContainer = "container:Bookmarks.xcodeproj">
+               ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
@@ -45,7 +45,7 @@
                BlueprintIdentifier = "D8D3BC1421C6AEBD00D6FB97"
                BuildableName = "BookmarksUITests.xctest"
                BlueprintName = "BookmarksUITests"
-               ReferencedContainer = "container:Bookmarks.xcodeproj">
+               ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -67,7 +67,7 @@
             BlueprintIdentifier = "D8D3BBF521C6AEBC00D6FB97"
             BuildableName = "Bookmarks.app"
             BlueprintName = "Bookmarks"
-            ReferencedContainer = "container:Bookmarks.xcodeproj">
+            ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </LaunchAction>
@@ -84,7 +84,7 @@
             BlueprintIdentifier = "D8D3BBF521C6AEBC00D6FB97"
             BuildableName = "Bookmarks.app"
             BlueprintName = "Bookmarks"
-            ReferencedContainer = "container:Bookmarks.xcodeproj">
+            ReferencedContainer = "container:Bookmarks-iOS.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,4 +21,4 @@ function build_scheme {
 }
 
 cd "$ROOT_DIRECTORY"
-build_scheme Bookmarks
+build_scheme "Bookmarks iOS"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,13 +7,13 @@ set -x
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ROOT_DIRECTORY="${SCRIPT_DIRECTORY}/.."
 
-PROJECT_PATH="${ROOT_DIRECTORY}/ios/Bookmarks.xcodeproj"
+WORKSPACE_PATH="${ROOT_DIRECTORY}/Bookmarks.xcworkspace"
 
 # TODO: Re-enable test builds if possible using a locally generated signing key.
 
 function build_scheme {
     xcodebuild \
-        -project "$PROJECT_PATH" \
+        -workspace "$WORKSPACE_PATH" \
         -scheme "$1" \
         clean \
         build \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,13 +7,11 @@ set -x
 SCRIPT_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 ROOT_DIRECTORY="${SCRIPT_DIRECTORY}/.."
 
-WORKSPACE_PATH="${ROOT_DIRECTORY}/Bookmarks.xcworkspace"
-
 # TODO: Re-enable test builds if possible using a locally generated signing key.
 
 function build_scheme {
     xcodebuild \
-        -workspace "$WORKSPACE_PATH" \
+        -workspace Bookmarks.xcworkspace \
         -scheme "$1" \
         clean \
         build \
@@ -22,4 +20,5 @@ function build_scheme {
         CODE_SIGNING_ALLOWED=NO
 }
 
+cd "$ROOT_DIRECTORY"
 build_scheme Bookmarks


### PR DESCRIPTION
This change introduces a top-level workspace in advance of adding dependencies like Sparkle, a core library, and a dedicated macOS target to the project.