### PR TITLE
Introduce BookmarksCore framework for sharing code between iOS and macOS

### DIFF
--- a/Bookmarks.xcworkspace/contents.xcworkspacedata
+++ b/Bookmarks.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:core/BookmarksCore.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:ios/Bookmarks-iOS.xcodeproj">
    </FileRef>
 </Workspace>

--- a/Bookmarks.xcworkspace/xcshareddata/xcschemes/BookmarksCore.xcscheme
+++ b/Bookmarks.xcworkspace/xcshareddata/xcschemes/BookmarksCore.xcscheme
@@ -14,20 +14,6 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D8D3BBF521C6AEBC00D6FB97"
-               BuildableName = "Bookmarks.app"
-               BlueprintName = "Bookmarks"
-               ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "D8569FC1261E2603006926BF"
                BuildableName = "BookmarksCore.framework"
                BlueprintName = "BookmarksCore"
@@ -46,20 +32,10 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D8D3BC0921C6AEBD00D6FB97"
-               BuildableName = "BookmarksTests.xctest"
-               BlueprintName = "BookmarksTests"
-               ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D8D3BC1421C6AEBD00D6FB97"
-               BuildableName = "BookmarksUITests.xctest"
-               BlueprintName = "BookmarksUITests"
-               ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
+               BlueprintIdentifier = "D8569FCA261E2603006926BF"
+               BuildableName = "BookmarksCoreTests.xctest"
+               BlueprintName = "BookmarksCoreTests"
+               ReferencedContainer = "container:core/BookmarksCore.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -74,16 +50,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D8D3BBF521C6AEBC00D6FB97"
-            BuildableName = "Bookmarks.app"
-            BlueprintName = "Bookmarks"
-            ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -91,16 +57,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D8D3BBF521C6AEBC00D6FB97"
-            BuildableName = "Bookmarks.app"
-            BlueprintName = "Bookmarks"
-            ReferencedContainer = "container:ios/Bookmarks-iOS.xcodeproj">
+            BlueprintIdentifier = "D8569FC1261E2603006926BF"
+            BuildableName = "BookmarksCore.framework"
+            BlueprintName = "BookmarksCore"
+            ReferencedContainer = "container:core/BookmarksCore.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/core/BookmarksCore.xcodeproj/project.pbxproj
+++ b/core/BookmarksCore.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		D84CE46D261E29A900AF1901 /* Boolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84CE46C261E29A900AF1901 /* Boolean.swift */; };
 		D84CE484261E2AD000AF1901 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84CE483261E2AD000AF1901 /* Post.swift */; };
+		D84CE488261E2B7D00AF1901 /* Pinboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84CE487261E2B7D00AF1901 /* Pinboard.swift */; };
 		D8569FCC261E2603006926BF /* BookmarksCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8569FC2261E2603006926BF /* BookmarksCore.framework */; };
 		D8569FD1261E2603006926BF /* BookmarksCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8569FD0261E2603006926BF /* BookmarksCoreTests.swift */; };
 		D8569FD3261E2603006926BF /* BookmarksCore.h in Headers */ = {isa = PBXBuildFile; fileRef = D8569FC5261E2603006926BF /* BookmarksCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -27,6 +28,7 @@
 /* Begin PBXFileReference section */
 		D84CE46C261E29A900AF1901 /* Boolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boolean.swift; sourceTree = "<group>"; };
 		D84CE483261E2AD000AF1901 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
+		D84CE487261E2B7D00AF1901 /* Pinboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pinboard.swift; sourceTree = "<group>"; };
 		D8569FC2261E2603006926BF /* BookmarksCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BookmarksCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8569FC5261E2603006926BF /* BookmarksCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BookmarksCore.h; sourceTree = "<group>"; };
 		D8569FC6261E2603006926BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -58,6 +60,7 @@
 			isa = PBXGroup;
 			children = (
 				D84CE46C261E29A900AF1901 /* Boolean.swift */,
+				D84CE487261E2B7D00AF1901 /* Pinboard.swift */,
 				D84CE483261E2AD000AF1901 /* Post.swift */,
 			);
 			path = Pinboard;
@@ -210,6 +213,7 @@
 			files = (
 				D84CE46D261E29A900AF1901 /* Boolean.swift in Sources */,
 				D84CE484261E2AD000AF1901 /* Post.swift in Sources */,
+				D84CE488261E2B7D00AF1901 /* Pinboard.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/core/BookmarksCore.xcodeproj/project.pbxproj
+++ b/core/BookmarksCore.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D84CE46D261E29A900AF1901 /* Boolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84CE46C261E29A900AF1901 /* Boolean.swift */; };
 		D8569FCC261E2603006926BF /* BookmarksCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8569FC2261E2603006926BF /* BookmarksCore.framework */; };
 		D8569FD1261E2603006926BF /* BookmarksCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8569FD0261E2603006926BF /* BookmarksCoreTests.swift */; };
 		D8569FD3261E2603006926BF /* BookmarksCore.h in Headers */ = {isa = PBXBuildFile; fileRef = D8569FC5261E2603006926BF /* BookmarksCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -23,6 +24,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D84CE46C261E29A900AF1901 /* Boolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boolean.swift; sourceTree = "<group>"; };
 		D8569FC2261E2603006926BF /* BookmarksCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BookmarksCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8569FC5261E2603006926BF /* BookmarksCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BookmarksCore.h; sourceTree = "<group>"; };
 		D8569FC6261E2603006926BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -50,6 +52,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D84CE462261E296F00AF1901 /* Pinboard */ = {
+			isa = PBXGroup;
+			children = (
+				D84CE46C261E29A900AF1901 /* Boolean.swift */,
+			);
+			path = Pinboard;
+			sourceTree = "<group>";
+		};
 		D8569FB8261E2603006926BF = {
 			isa = PBXGroup;
 			children = (
@@ -71,6 +81,7 @@
 		D8569FC4261E2603006926BF /* BookmarksCore */ = {
 			isa = PBXGroup;
 			children = (
+				D84CE462261E296F00AF1901 /* Pinboard */,
 				D8569FC5261E2603006926BF /* BookmarksCore.h */,
 				D8569FC6261E2603006926BF /* Info.plist */,
 			);
@@ -194,6 +205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D84CE46D261E29A900AF1901 /* Boolean.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -269,7 +281,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -329,7 +341,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -393,6 +405,7 @@
 		D8569FDA261E2603006926BF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S4WXAUZQEV;
 				INFOPLIST_FILE = BookmarksCoreTests/Info.plist;
@@ -411,6 +424,7 @@
 		D8569FDB261E2603006926BF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = S4WXAUZQEV;
 				INFOPLIST_FILE = BookmarksCoreTests/Info.plist;

--- a/core/BookmarksCore.xcodeproj/project.pbxproj
+++ b/core/BookmarksCore.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D84CE46D261E29A900AF1901 /* Boolean.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84CE46C261E29A900AF1901 /* Boolean.swift */; };
+		D84CE484261E2AD000AF1901 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84CE483261E2AD000AF1901 /* Post.swift */; };
 		D8569FCC261E2603006926BF /* BookmarksCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8569FC2261E2603006926BF /* BookmarksCore.framework */; };
 		D8569FD1261E2603006926BF /* BookmarksCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8569FD0261E2603006926BF /* BookmarksCoreTests.swift */; };
 		D8569FD3261E2603006926BF /* BookmarksCore.h in Headers */ = {isa = PBXBuildFile; fileRef = D8569FC5261E2603006926BF /* BookmarksCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -25,6 +26,7 @@
 
 /* Begin PBXFileReference section */
 		D84CE46C261E29A900AF1901 /* Boolean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Boolean.swift; sourceTree = "<group>"; };
+		D84CE483261E2AD000AF1901 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		D8569FC2261E2603006926BF /* BookmarksCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BookmarksCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8569FC5261E2603006926BF /* BookmarksCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BookmarksCore.h; sourceTree = "<group>"; };
 		D8569FC6261E2603006926BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -56,6 +58,7 @@
 			isa = PBXGroup;
 			children = (
 				D84CE46C261E29A900AF1901 /* Boolean.swift */,
+				D84CE483261E2AD000AF1901 /* Post.swift */,
 			);
 			path = Pinboard;
 			sourceTree = "<group>";
@@ -206,6 +209,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D84CE46D261E29A900AF1901 /* Boolean.swift in Sources */,
+				D84CE484261E2AD000AF1901 /* Post.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/core/BookmarksCore.xcodeproj/project.pbxproj
+++ b/core/BookmarksCore.xcodeproj/project.pbxproj
@@ -1,0 +1,462 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D8569FCC261E2603006926BF /* BookmarksCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8569FC2261E2603006926BF /* BookmarksCore.framework */; };
+		D8569FD1261E2603006926BF /* BookmarksCoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8569FD0261E2603006926BF /* BookmarksCoreTests.swift */; };
+		D8569FD3261E2603006926BF /* BookmarksCore.h in Headers */ = {isa = PBXBuildFile; fileRef = D8569FC5261E2603006926BF /* BookmarksCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		D8569FCD261E2603006926BF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D8569FB9261E2603006926BF /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D8569FC1261E2603006926BF;
+			remoteInfo = BookmarksCore;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		D8569FC2261E2603006926BF /* BookmarksCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BookmarksCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D8569FC5261E2603006926BF /* BookmarksCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BookmarksCore.h; sourceTree = "<group>"; };
+		D8569FC6261E2603006926BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D8569FCB261E2603006926BF /* BookmarksCoreTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BookmarksCoreTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D8569FD0261E2603006926BF /* BookmarksCoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksCoreTests.swift; sourceTree = "<group>"; };
+		D8569FD2261E2603006926BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D8569FBF261E2603006926BF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D8569FC8261E2603006926BF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D8569FCC261E2603006926BF /* BookmarksCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D8569FB8261E2603006926BF = {
+			isa = PBXGroup;
+			children = (
+				D8569FC4261E2603006926BF /* BookmarksCore */,
+				D8569FCF261E2603006926BF /* BookmarksCoreTests */,
+				D8569FC3261E2603006926BF /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D8569FC3261E2603006926BF /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D8569FC2261E2603006926BF /* BookmarksCore.framework */,
+				D8569FCB261E2603006926BF /* BookmarksCoreTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D8569FC4261E2603006926BF /* BookmarksCore */ = {
+			isa = PBXGroup;
+			children = (
+				D8569FC5261E2603006926BF /* BookmarksCore.h */,
+				D8569FC6261E2603006926BF /* Info.plist */,
+			);
+			path = BookmarksCore;
+			sourceTree = "<group>";
+		};
+		D8569FCF261E2603006926BF /* BookmarksCoreTests */ = {
+			isa = PBXGroup;
+			children = (
+				D8569FD0261E2603006926BF /* BookmarksCoreTests.swift */,
+				D8569FD2261E2603006926BF /* Info.plist */,
+			);
+			path = BookmarksCoreTests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		D8569FBD261E2603006926BF /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D8569FD3261E2603006926BF /* BookmarksCore.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		D8569FC1261E2603006926BF /* BookmarksCore */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D8569FD6261E2603006926BF /* Build configuration list for PBXNativeTarget "BookmarksCore" */;
+			buildPhases = (
+				D8569FBD261E2603006926BF /* Headers */,
+				D8569FBE261E2603006926BF /* Sources */,
+				D8569FBF261E2603006926BF /* Frameworks */,
+				D8569FC0261E2603006926BF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BookmarksCore;
+			productName = BookmarksCore;
+			productReference = D8569FC2261E2603006926BF /* BookmarksCore.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		D8569FCA261E2603006926BF /* BookmarksCoreTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D8569FD9261E2603006926BF /* Build configuration list for PBXNativeTarget "BookmarksCoreTests" */;
+			buildPhases = (
+				D8569FC7261E2603006926BF /* Sources */,
+				D8569FC8261E2603006926BF /* Frameworks */,
+				D8569FC9261E2603006926BF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D8569FCE261E2603006926BF /* PBXTargetDependency */,
+			);
+			name = BookmarksCoreTests;
+			productName = BookmarksCoreTests;
+			productReference = D8569FCB261E2603006926BF /* BookmarksCoreTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D8569FB9261E2603006926BF /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1240;
+				LastUpgradeCheck = 1240;
+				TargetAttributes = {
+					D8569FC1261E2603006926BF = {
+						CreatedOnToolsVersion = 12.4;
+					};
+					D8569FCA261E2603006926BF = {
+						CreatedOnToolsVersion = 12.4;
+					};
+				};
+			};
+			buildConfigurationList = D8569FBC261E2603006926BF /* Build configuration list for PBXProject "BookmarksCore" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D8569FB8261E2603006926BF;
+			productRefGroup = D8569FC3261E2603006926BF /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D8569FC1261E2603006926BF /* BookmarksCore */,
+				D8569FCA261E2603006926BF /* BookmarksCoreTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D8569FC0261E2603006926BF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D8569FC9261E2603006926BF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D8569FBE261E2603006926BF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D8569FC7261E2603006926BF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D8569FD1261E2603006926BF /* BookmarksCoreTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D8569FCE261E2603006926BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D8569FC1261E2603006926BF /* BookmarksCore */;
+			targetProxy = D8569FCD261E2603006926BF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		D8569FD4261E2603006926BF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		D8569FD5261E2603006926BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		D8569FD7261E2603006926BF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = S4WXAUZQEV;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BookmarksCore/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.inseven.BookmarksCore;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D8569FD8261E2603006926BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = S4WXAUZQEV;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = BookmarksCore/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.inseven.BookmarksCore;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		D8569FDA261E2603006926BF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = S4WXAUZQEV;
+				INFOPLIST_FILE = BookmarksCoreTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.inseven.BookmarksCoreTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D8569FDB261E2603006926BF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = S4WXAUZQEV;
+				INFOPLIST_FILE = BookmarksCoreTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = uk.co.inseven.BookmarksCoreTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D8569FBC261E2603006926BF /* Build configuration list for PBXProject "BookmarksCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D8569FD4261E2603006926BF /* Debug */,
+				D8569FD5261E2603006926BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D8569FD6261E2603006926BF /* Build configuration list for PBXNativeTarget "BookmarksCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D8569FD7261E2603006926BF /* Debug */,
+				D8569FD8261E2603006926BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D8569FD9261E2603006926BF /* Build configuration list for PBXNativeTarget "BookmarksCoreTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D8569FDA261E2603006926BF /* Debug */,
+				D8569FDB261E2603006926BF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D8569FB9261E2603006926BF /* Project object */;
+}

--- a/core/BookmarksCore/BookmarksCore.h
+++ b/core/BookmarksCore/BookmarksCore.h
@@ -20,12 +20,5 @@
 
 #import <Foundation/Foundation.h>
 
-//! Project version number for BookmarksCore.
 FOUNDATION_EXPORT double BookmarksCoreVersionNumber;
-
-//! Project version string for BookmarksCore.
 FOUNDATION_EXPORT const unsigned char BookmarksCoreVersionString[];
-
-// In this header, you should import all the public headers of your framework using statements like #import <BookmarksCore/PublicHeader.h>
-
-

--- a/core/BookmarksCore/BookmarksCore.h
+++ b/core/BookmarksCore/BookmarksCore.h
@@ -1,9 +1,22 @@
+// Copyright (c) 2020-2021 InSeven Limited
 //
-//  BookmarksCore.h
-//  BookmarksCore
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 07/04/2021.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #import <Foundation/Foundation.h>
 

--- a/core/BookmarksCore/BookmarksCore.h
+++ b/core/BookmarksCore/BookmarksCore.h
@@ -1,0 +1,18 @@
+//
+//  BookmarksCore.h
+//  BookmarksCore
+//
+//  Created by Jason Barrie Morley on 07/04/2021.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for BookmarksCore.
+FOUNDATION_EXPORT double BookmarksCoreVersionNumber;
+
+//! Project version string for BookmarksCore.
+FOUNDATION_EXPORT const unsigned char BookmarksCoreVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <BookmarksCore/PublicHeader.h>
+
+

--- a/core/BookmarksCore/Info.plist
+++ b/core/BookmarksCore/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/core/BookmarksCore/Pinboard/Boolean.swift
+++ b/core/BookmarksCore/Pinboard/Boolean.swift
@@ -1,0 +1,26 @@
+// Copyright (c) 2020-2021 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+public enum Boolean: String, Codable {
+    case yes = "yes"
+    case no = "no"
+}

--- a/core/BookmarksCore/Pinboard/Pinboard.swift
+++ b/core/BookmarksCore/Pinboard/Pinboard.swift
@@ -20,36 +20,34 @@
 
 import Foundation
 
-import BookmarksCore
+public class Pinboard {
 
-class Pinboard {
+    enum Error: Swift.Error {
+        case invalidURL(message: String)
+        case invalidResponse(message: String)
+        case inconsistentState(message: String)
+    }
 
     let baseURL = "https://api.pinboard.in/v1/"
     let postsAll = "posts/all"
 
     let token: String
 
-    enum PinboardError: Error {
-        case invalidURL(message: String)
-        case invalidResponse(message: String)
-        case inconsistentState(message: String)
-    }
-
     public init(token: String) {
         self.token = token
     }
 
-    func fetch(completion: @escaping (Result<[Post], Error>) -> Void) {
+    public func fetch(completion: @escaping (Result<[Post], Swift.Error>) -> Void) {
         guard let base = URL(string: baseURL) else {
             DispatchQueue.global(qos: .default).async {
-                completion(.failure(PinboardError.invalidURL(message: "Unable to construct parse base URL")))
+                completion(.failure(Error.invalidURL(message: "Unable to construct parse base URL")))
             }
             return
         }
         let posts = base.appendingPathComponent(postsAll)
         guard var components = URLComponents(string: posts.absoluteString) else {
             DispatchQueue.global(qos: .default).async {
-                completion(.failure(PinboardError.invalidURL(message: "Unable to parse URL components")))
+                completion(.failure(Error.invalidURL(message: "Unable to parse URL components")))
             }
             return
         }
@@ -59,14 +57,14 @@ class Pinboard {
         ]
         guard let url = components.url else {
             DispatchQueue.global(qos: .default).async {
-                completion(.failure(PinboardError.invalidURL(message: "Unable to construct URL from components")))
+                completion(.failure(Error.invalidURL(message: "Unable to construct URL from components")))
             }
             return
         }
         let task = URLSession.shared.dataTask(with: url) { (data, response, error) in
             guard let data = data else {
                 guard let error = error else {
-                    completion(.failure(PinboardError.inconsistentState(message: "Missing error when processing URL completion")))
+                    completion(.failure(Error.inconsistentState(message: "Missing error when processing URL completion")))
                     return
                 }
                 completion(.failure(error))

--- a/core/BookmarksCore/Pinboard/Post.swift
+++ b/core/BookmarksCore/Pinboard/Post.swift
@@ -1,0 +1,69 @@
+// Copyright (c) 2020-2021 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+public struct Post: Codable {
+
+    public let description: String?
+    public let extended: String
+    public let hash: String
+    public let href: URL?
+    public let meta: String
+    public let shared: Bool
+    public let tags: [String]
+    public let time: Date?
+    public let toRead: Bool
+
+    public enum CodingKeys: String, CodingKey {
+        case description = "description"
+        case extended = "extended"
+        case hash = "hash"
+        case href = "href"
+        case meta = "meta"
+        case shared = "shared"
+        case tags = "tags"
+        case time = "time"
+        case toRead = "toread"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Unfortunately, the Pinboard API uses 0 as a placeholder for a missing description, so we need to do a little
+        // dance here to keep everything happy.
+        do {
+            description = try container.decode(String.self, forKey: .description)
+        } catch DecodingError.typeMismatch {
+            // We double check that we can parse the key as a boolean to ensure the structure is as we expect.
+            let _ = try container.decode(Bool.self, forKey: .description)
+            description = nil
+        }
+
+        extended = try container.decode(String.self, forKey: .extended)
+        href = URL(string: try container.decode(String.self, forKey: .href))
+        hash = try container.decode(String.self, forKey: .hash)
+        meta = try container.decode(String.self, forKey: .meta)
+        shared = try container.decode(Boolean.self, forKey: .shared) == .yes ? true : false
+        tags = try container.decode(String.self, forKey: .tags).split(separator: " ").map(String.init)
+        time = ISO8601DateFormatter.init().date(from: try container.decode(String.self, forKey: .time))
+        toRead = try container.decode(Boolean.self, forKey: .toRead) == .yes ? true : false
+    }
+}

--- a/core/BookmarksCoreTests/BookmarksCoreTests.swift
+++ b/core/BookmarksCoreTests/BookmarksCoreTests.swift
@@ -1,33 +1,26 @@
+// Copyright (c) 2020-2021 InSeven Limited
 //
-//  BookmarksCoreTests.swift
-//  BookmarksCoreTests
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-//  Created by Jason Barrie Morley on 07/04/2021.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import XCTest
 @testable import BookmarksCore
 
 class BookmarksCoreTests: XCTestCase {
-
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
 
 }

--- a/core/BookmarksCoreTests/BookmarksCoreTests.swift
+++ b/core/BookmarksCoreTests/BookmarksCoreTests.swift
@@ -1,0 +1,33 @@
+//
+//  BookmarksCoreTests.swift
+//  BookmarksCoreTests
+//
+//  Created by Jason Barrie Morley on 07/04/2021.
+//
+
+import XCTest
+@testable import BookmarksCore
+
+class BookmarksCoreTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/core/BookmarksCoreTests/Info.plist
+++ b/core/BookmarksCoreTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
+++ b/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		D8D3BC0421C6AEBD00D6FB97 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D8D3BC0221C6AEBD00D6FB97 /* LaunchScreen.storyboard */; };
 		D8D3BC0F21C6AEBD00D6FB97 /* BookmarksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3BC0E21C6AEBD00D6FB97 /* BookmarksTests.swift */; };
 		D8D3BC1A21C6AEBD00D6FB97 /* BookmarksUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3BC1921C6AEBD00D6FB97 /* BookmarksUITests.swift */; };
-		D8D3BC2A21C72F7600D6FB97 /* Pinboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3BC2921C72F7600D6FB97 /* Pinboard.swift */; };
 		D8D3E4F3254D8EBB00A72446 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3E4F2254D8EBB00A72446 /* Item.swift */; };
 		D8D3E4F8254D957700A72446 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3E4F7254D957700A72446 /* View.swift */; };
 		D8D3E4FD254E753F00A72446 /* NSCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3E4FC254E753F00A72446 /* NSCoder.swift */; };
@@ -118,7 +117,6 @@
 		D8D3BC1521C6AEBD00D6FB97 /* BookmarksUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BookmarksUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8D3BC1921C6AEBD00D6FB97 /* BookmarksUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksUITests.swift; sourceTree = "<group>"; };
 		D8D3BC1B21C6AEBD00D6FB97 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D8D3BC2921C72F7600D6FB97 /* Pinboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pinboard.swift; sourceTree = "<group>"; };
 		D8D3E4F2254D8EBB00A72446 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
 		D8D3E4F7254D957700A72446 /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		D8D3E4FC254E753F00A72446 /* NSCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSCoder.swift; sourceTree = "<group>"; };
@@ -168,7 +166,6 @@
 				D84785912615478800B2318B /* BookmarksError.swift */,
 				D832EEBC24816655004C64E3 /* Document.swift */,
 				D8A131F3248C4FDA006E71BE /* DownloadManager.swift */,
-				D8D3BC2921C72F7600D6FB97 /* Pinboard.swift */,
 				D81D019C247B0AA200C8324B /* Store.swift */,
 				D8A3A51E247C918000C3B8B4 /* ThumbnailManager.swift */,
 				D81D01A0247B29B500C8324B /* Updater.swift */,
@@ -443,7 +440,6 @@
 				D8A3A51F247C918000C3B8B4 /* ThumbnailManager.swift in Sources */,
 				D847858A2615476B00B2318B /* String.swift in Sources */,
 				D84785822615474900B2318B /* SearchBoxModifier.swift in Sources */,
-				D8D3BC2A21C72F7600D6FB97 /* Pinboard.swift in Sources */,
 				D81D01A1247B29B500C8324B /* Updater.swift in Sources */,
 				D8A131F4248C4FDA006E71BE /* DownloadManager.swift in Sources */,
 				D832EEBD24816655004C64E3 /* Document.swift in Sources */,

--- a/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
+++ b/ios/Bookmarks-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		D84785822615474900B2318B /* SearchBoxModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84785812615474900B2318B /* SearchBoxModifier.swift */; };
 		D847858A2615476B00B2318B /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84785892615476B00B2318B /* String.swift */; };
 		D84785922615478800B2318B /* BookmarksError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D84785912615478800B2318B /* BookmarksError.swift */; };
+		D84CE47E261E2A1400AF1901 /* BookmarksCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D84CE47D261E2A1400AF1901 /* BookmarksCore.framework */; };
+		D84CE47F261E2A1400AF1901 /* BookmarksCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D84CE47D261E2A1400AF1901 /* BookmarksCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D864E46C21C93FB400EAB9AD /* TFHpple.m in Sources */ = {isa = PBXBuildFile; fileRef = D864E46721C93FB400EAB9AD /* TFHpple.m */; };
 		D864E46D21C93FB400EAB9AD /* TFHppleElement.m in Sources */ = {isa = PBXBuildFile; fileRef = D864E46A21C93FB400EAB9AD /* TFHppleElement.m */; };
 		D864E46E21C93FB400EAB9AD /* XPathQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = D864E46B21C93FB400EAB9AD /* XPathQuery.m */; };
@@ -60,6 +62,20 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		D84CE480261E2A1400AF1901 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				D84CE47F261E2A1400AF1901 /* BookmarksCore.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		D81D019C247B0AA200C8324B /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		D81D019E247B24D600C8324B /* Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
@@ -78,6 +94,7 @@
 		D84785812615474900B2318B /* SearchBoxModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxModifier.swift; sourceTree = "<group>"; };
 		D84785892615476B00B2318B /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		D84785912615478800B2318B /* BookmarksError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksError.swift; sourceTree = "<group>"; };
+		D84CE47D261E2A1400AF1901 /* BookmarksCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BookmarksCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D864E46621C93FB400EAB9AD /* TFHppleElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TFHppleElement.h; sourceTree = "<group>"; };
 		D864E46721C93FB400EAB9AD /* TFHpple.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TFHpple.m; sourceTree = "<group>"; };
 		D864E46821C93FB400EAB9AD /* XPathQuery.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XPathQuery.h; sourceTree = "<group>"; };
@@ -113,6 +130,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D864E47121C93FD200EAB9AD /* libxml2.2.tbd in Frameworks */,
+				D84CE47E261E2A1400AF1901 /* BookmarksCore.framework in Frameworks */,
 				D8BDE1472554782000C95945 /* Introspect in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -201,6 +219,7 @@
 		D864E46F21C93FD200EAB9AD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D84CE47D261E2A1400AF1901 /* BookmarksCore.framework */,
 				D864E47021C93FD200EAB9AD /* libxml2.2.tbd */,
 			);
 			name = Frameworks;
@@ -275,6 +294,7 @@
 				D8D3BBF221C6AEBC00D6FB97 /* Sources */,
 				D8D3BBF321C6AEBC00D6FB97 /* Frameworks */,
 				D8D3BBF421C6AEBC00D6FB97 /* Resources */,
+				D84CE480261E2A1400AF1901 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/ios/Bookmarks/Core/Pinboard.swift
+++ b/ios/Bookmarks/Core/Pinboard.swift
@@ -20,12 +20,10 @@
 
 import Foundation
 
+import BookmarksCore
+
 // Believe it or not, Pinboard represents booleans as the strings 'yes' and 'no', causing us to play some very silly
 // games.
-enum Boolean: String, Codable {
-    case yes = "yes"
-    case no = "no"
-}
 
 struct Post: Codable {
     let description: String?

--- a/ios/Bookmarks/Core/Pinboard.swift
+++ b/ios/Bookmarks/Core/Pinboard.swift
@@ -22,56 +22,6 @@ import Foundation
 
 import BookmarksCore
 
-// Believe it or not, Pinboard represents booleans as the strings 'yes' and 'no', causing us to play some very silly
-// games.
-
-struct Post: Codable {
-    let description: String?
-    let extended: String
-    let hash: String
-    let href: URL?
-    let meta: String
-    let shared: Bool
-    let tags: [String]
-    let time: Date?
-    let toRead: Bool
-
-    enum CodingKeys: String, CodingKey {
-        case description = "description"
-        case extended = "extended"
-        case hash = "hash"
-        case href = "href"
-        case meta = "meta"
-        case shared = "shared"
-        case tags = "tags"
-        case time = "time"
-        case toRead = "toread"
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-
-        // Unfortunately, the Pinboard API uses 0 as a placeholder for a missing description, so we need to do a little
-        // dance here to keep everything happy.
-        do {
-            description = try container.decode(String.self, forKey: .description)
-        } catch DecodingError.typeMismatch {
-            // We double check that we can parse the key as a boolean to ensure the structure is as we expect.
-            let _ = try container.decode(Bool.self, forKey: .description)
-            description = nil
-        }
-
-        extended = try container.decode(String.self, forKey: .extended)
-        href = URL(string: try container.decode(String.self, forKey: .href))
-        hash = try container.decode(String.self, forKey: .hash)
-        meta = try container.decode(String.self, forKey: .meta)
-        shared = try container.decode(Boolean.self, forKey: .shared) == .yes ? true : false
-        tags = try container.decode(String.self, forKey: .tags).split(separator: " ").map(String.init)
-        time = ISO8601DateFormatter.init().date(from: try container.decode(String.self, forKey: .time))
-        toRead = try container.decode(Boolean.self, forKey: .toRead) == .yes ? true : false
-    }
-}
-
 class Pinboard {
 
     let baseURL = "https://api.pinboard.in/v1/"

--- a/ios/Bookmarks/Core/Updater.swift
+++ b/ios/Bookmarks/Core/Updater.swift
@@ -20,6 +20,8 @@
 
 import Foundation
 
+import BookmarksCore
+
 protocol UpdaterObserver: AnyObject {
 
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,4 +21,5 @@ function build_scheme {
 }
 
 cd "$ROOT_DIRECTORY"
+build_scheme "BookmarksCore"
 build_scheme "Bookmarks iOS"


### PR DESCRIPTION
This introduces BookmarksCore.framework to make it easier to share code between the iOS app and a future macOS app. In order to check everything's working smoothly, it moves the Pinboard API into the new framework and cleans up the code a little.