### PR TITLE
Add settings view and pinboard key setting

### DIFF
--- a/ios/Bookmarks/Interface/SettingsView.swift
+++ b/ios/Bookmarks/Interface/SettingsView.swift
@@ -41,7 +41,9 @@ struct SettingsView: View {
                 Section(header: Text("Pinboard")) {
                     TextField("API Token", text: $settings.pinboardApiKey)
                     Button(action: {
-                        UIApplication.shared.open(URL(string: "https://pinboard.in/settings/password")!, options: [:], completionHandler: nil)
+                        UIApplication.shared.open(URL(string: "https://pinboard.in/settings/password")!,
+                                                  options: [:],
+                                                  completionHandler: nil)
                     }, label: {
                         Text("Get your API token")
                     })

--- a/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
+++ b/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		D81EA6032620F3D5000AB851 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = D81EA6022620F3D5000AB851 /* Sparkle */; };
+		D840B006262103C4001E95D1 /* AccountSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D840B005262103C4001E95D1 /* AccountSettingsView.swift */; };
+		D840B00A2621042B001E95D1 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D840B0092621042B001E95D1 /* SettingsView.swift */; };
+		D840B01226210AF6001E95D1 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D840B01126210AF6001E95D1 /* GeneralSettingsView.swift */; };
 		D891C454261E32F90024E1A6 /* BookmarksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891C453261E32F90024E1A6 /* BookmarksApp.swift */; };
 		D891C456261E32F90024E1A6 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891C455261E32F90024E1A6 /* ContentView.swift */; };
 		D891C458261E32FB0024E1A6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D891C457261E32FB0024E1A6 /* Assets.xcassets */; };
@@ -54,6 +57,9 @@
 
 /* Begin PBXFileReference section */
 		D81EA5FF2620F3BF000AB851 /* sparkle */ = {isa = PBXFileReference; lastKnownFileType = folder; name = sparkle; path = ../sparkle; sourceTree = "<group>"; };
+		D840B005262103C4001E95D1 /* AccountSettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsView.swift; sourceTree = "<group>"; };
+		D840B0092621042B001E95D1 /* SettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		D840B01126210AF6001E95D1 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		D891C450261E32F90024E1A6 /* Bookmarks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Bookmarks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D891C453261E32F90024E1A6 /* BookmarksApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksApp.swift; sourceTree = "<group>"; };
 		D891C455261E32F90024E1A6 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -168,8 +174,11 @@
 		D8B04B43261F4A1200376ADD /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				D840B005262103C4001E95D1 /* AccountSettingsView.swift */,
 				D8B04B3F261F49F100376ADD /* BookmarkCell.swift */,
 				D891C455261E32F90024E1A6 /* ContentView.swift */,
+				D840B01126210AF6001E95D1 /* GeneralSettingsView.swift */,
+				D840B0092621042B001E95D1 /* SettingsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -326,7 +335,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8B6E2C52620990400B2C239 /* Item.swift in Sources */,
+				D840B006262103C4001E95D1 /* AccountSettingsView.swift in Sources */,
 				D891C456261E32F90024E1A6 /* ContentView.swift in Sources */,
+				D840B01226210AF6001E95D1 /* GeneralSettingsView.swift in Sources */,
+				D840B00A2621042B001E95D1 /* SettingsView.swift in Sources */,
 				D891C454261E32F90024E1A6 /* BookmarksApp.swift in Sources */,
 				D8B04B40261F49F100376ADD /* BookmarkCell.swift in Sources */,
 			);

--- a/macos/Bookmarks/Views/AccountSettingsView.swift
+++ b/macos/Bookmarks/Views/AccountSettingsView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 InSeven Limited
+// Copyright (c) 2018-2021 InSeven Limited
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,17 +22,27 @@ import SwiftUI
 
 import BookmarksCore
 
-@main
-struct BookmarksApp: App {
+struct AccountSettingsView: View {
 
     @Environment(\.manager) var manager: BookmarksManager
 
-    var body: some Scene {
-        WindowGroup {
-            ContentView(store: manager.store)
-        }
-        SwiftUI.Settings {
-            SettingsView()
+    @ObservedObject var settings: BookmarksCore.Settings
+
+    var body: some View {
+        VStack {
+            Form {
+                Section {
+                    TextField("API Token", text: $settings.pinboardApiKey)
+                    Button(action: {
+                        NSWorkspace.shared.open(URL(string: "https://pinboard.in/settings/password")!)
+                    }, label: {
+                        Text("Get your API token")
+                    })
+                    .buttonStyle(LinkButtonStyle())
+                }
+            }
+            Spacer()
         }
     }
+
 }

--- a/macos/Bookmarks/Views/GeneralSettingsView.swift
+++ b/macos/Bookmarks/Views/GeneralSettingsView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 InSeven Limited
+// Copyright (c) 2018-2021 InSeven Limited
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,17 +22,18 @@ import SwiftUI
 
 import BookmarksCore
 
-@main
-struct BookmarksApp: App {
+struct GeneralSettingsView: View {
 
     @Environment(\.manager) var manager: BookmarksManager
 
-    var body: some Scene {
-        WindowGroup {
-            ContentView(store: manager.store)
-        }
-        SwiftUI.Settings {
-            SettingsView()
+    @ObservedObject var settings: BookmarksCore.Settings
+
+    var body: some View {
+        VStack {
+            Form {
+            }
+            Spacer()
         }
     }
+
 }

--- a/macos/Bookmarks/Views/SettingsView.swift
+++ b/macos/Bookmarks/Views/SettingsView.swift
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 InSeven Limited
+// Copyright (c) 2018-2021 InSeven Limited
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -22,17 +22,31 @@ import SwiftUI
 
 import BookmarksCore
 
-@main
-struct BookmarksApp: App {
+struct SettingsView: View {
+
+    private enum Tabs: Hashable {
+        case general
+        case account
+    }
 
     @Environment(\.manager) var manager: BookmarksManager
 
-    var body: some Scene {
-        WindowGroup {
-            ContentView(store: manager.store)
+    var body: some View {
+        EmptyView()
+        TabView {
+            GeneralSettingsView(settings: manager.settings)
+                .tabItem {
+                    Label("General", systemImage: "gear")
+                }
+                .tag(Tabs.general)
+            AccountSettingsView(settings: manager.settings)
+                .tabItem {
+                    Label("Account", systemImage: "at")
+                }
+                .tag(Tabs.account)
         }
-        SwiftUI.Settings {
-            SettingsView()
-        }
+        .padding()
+        .frame(minWidth: 320, maxWidth: .infinity)
     }
+
 }


### PR DESCRIPTION
This change adds a new Settings view to the macOS app with a couple of tabs: General and Account. General is entirely empty, but Account contains the Pinboard key, meaning new users will now be able to get started with the app.