### PR TITLE
Update bookmarks when foregrounding the macOS app

### DIFF
--- a/core/BookmarksCore/Common/BookmarksManager.swift
+++ b/core/BookmarksCore/Common/BookmarksManager.swift
@@ -41,7 +41,7 @@ public class BookmarksManager {
     public var settings = Settings()
     public var updater: Updater
 
-    init() {
+    public init() {
         documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         try! FileManager.default.createDirectory(at: documentsUrl, withIntermediateDirectories: true, attributes: nil)
         store = Store(path: documentsUrl.appendingPathComponent("store.plist"), targetQueue: .main)

--- a/core/BookmarksCore/Common/Updater.swift
+++ b/core/BookmarksCore/Common/Updater.swift
@@ -35,6 +35,7 @@ public class Updater {
     }
 
     public func start() {
+        print("Updating bookmarks...")
         Pinboard(token: self.token).posts_all { [weak self] (result) in
             switch (result) {
             case .failure(let error):

--- a/ios/Bookmarks/BookmarksApp.swift
+++ b/ios/Bookmarks/BookmarksApp.swift
@@ -36,12 +36,6 @@ struct BookmarksApp: App {
             switch phase {
             case .active:
                 manager.updater.start()
-                #if targetEnvironment(macCatalyst)
-                if let titlebar = UIApplication.shared.windows.first?.windowScene?.titlebar {
-                    titlebar.titleVisibility = .hidden
-                    titlebar.toolbar = nil
-                }
-                #endif
             case .background:
                 break
             case .inactive:

--- a/macos/Bookmarks/BookmarksApp.swift
+++ b/macos/Bookmarks/BookmarksApp.swift
@@ -18,21 +18,34 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import AppKit
 import SwiftUI
 
 import BookmarksCore
 
+class AppDelegate: NSObject, NSApplicationDelegate {
+
+    var manager = BookmarksManager()
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        manager.updater.start()
+    }
+}
+
 @main
 struct BookmarksApp: App {
 
+    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @Environment(\.manager) var manager: BookmarksManager
 
     var body: some Scene {
         WindowGroup {
             ContentView(store: manager.store)
+                .environment(\.manager, appDelegate.manager)
         }
         SwiftUI.Settings {
             SettingsView()
+                .environment(\.manager, appDelegate.manager)
         }
     }
 }


### PR DESCRIPTION
This functionality exists in the iOS app, but hadn't been brought over to macOS yet.