### PR TITLE
Save the main window frame

### DIFF
--- a/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
+++ b/macos/Bookmarks-macOS.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		D891C45B261E32FB0024E1A6 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D891C45A261E32FB0024E1A6 /* Preview Assets.xcassets */; };
 		D891C467261E32FB0024E1A6 /* BookmarksTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891C466261E32FB0024E1A6 /* BookmarksTests.swift */; };
 		D891C472261E32FB0024E1A6 /* BookmarksUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D891C471261E32FB0024E1A6 /* BookmarksUITests.swift */; };
+		D8A051FD2623432000532D1E /* FrameAutosaveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A051FC2623432000532D1E /* FrameAutosaveView.swift */; };
 		D8A0D7662620165D00C9F190 /* Interact in Frameworks */ = {isa = PBXBuildFile; productRef = D8A0D7652620165D00C9F190 /* Interact */; };
 		D8B04B40261F49F100376ADD /* BookmarkCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B04B3F261F49F100376ADD /* BookmarkCell.swift */; };
 		D8B6E2C52620990400B2C239 /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6E2C42620990400B2C239 /* Item.swift */; };
@@ -73,6 +74,7 @@
 		D891C46D261E32FB0024E1A6 /* BookmarksUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BookmarksUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D891C471261E32FB0024E1A6 /* BookmarksUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarksUITests.swift; sourceTree = "<group>"; };
 		D891C473261E32FB0024E1A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D8A051FC2623432000532D1E /* FrameAutosaveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameAutosaveView.swift; sourceTree = "<group>"; };
 		D8A0D75A262015E700C9F190 /* interact */ = {isa = PBXFileReference; lastKnownFileType = folder; name = interact; path = ../interact; sourceTree = "<group>"; };
 		D8B04B3F261F49F100376ADD /* BookmarkCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookmarkCell.swift; sourceTree = "<group>"; };
 		D8B6E2C42620990400B2C239 /* Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 				D891C455261E32F90024E1A6 /* ContentView.swift */,
 				D840B01126210AF6001E95D1 /* GeneralSettingsView.swift */,
 				D840B0092621042B001E95D1 /* SettingsView.swift */,
+				D8A051FC2623432000532D1E /* FrameAutosaveView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -334,6 +337,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D8A051FD2623432000532D1E /* FrameAutosaveView.swift in Sources */,
 				D8B6E2C52620990400B2C239 /* Item.swift in Sources */,
 				D840B006262103C4001E95D1 /* AccountSettingsView.swift in Sources */,
 				D891C456261E32F90024E1A6 /* ContentView.swift in Sources */,

--- a/macos/Bookmarks/Views/ContentView.swift
+++ b/macos/Bookmarks/Views/ContentView.swift
@@ -47,6 +47,10 @@ struct ContentView: View {
                                 NSWorkspace.shared.open(item.url)
                             }
                             .contextMenu(ContextMenu(menuItems: {
+                                Button("Open") {
+                                    NSWorkspace.shared.open(item.url)
+                                }
+                                Divider()
                                 Button("Share") {
                                     print("Share")
                                     print(item.identifier)
@@ -70,5 +74,6 @@ struct ContentView: View {
                     .frame(minWidth: 100, idealWidth: 300, maxWidth: .infinity)
             }
         }
+        .frameAutosaveName("Main Window")
     }
 }

--- a/macos/Bookmarks/Views/FrameAutosaveView.swift
+++ b/macos/Bookmarks/Views/FrameAutosaveView.swift
@@ -1,0 +1,101 @@
+// Copyright (c) 2018-2021 InSeven Limited
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftUI
+
+public struct FrameAutosaveView: NSViewRepresentable {
+
+    public class FrameAutosaveNSView: NSView {
+
+        var name: String
+
+        init(name: String) {
+            self.name = name
+            super.init(frame: .zero)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        public override func viewDidMoveToWindow() {
+            if let frameDescriptor = UserDefaults.standard.string(forKey: name) {
+                window?.setFrame(from: frameDescriptor)
+            }
+            NotificationCenter.default.addObserver(forName: NSView.frameDidChangeNotification,
+                                                   object: nil,
+                                                   queue: nil) { (notification) in
+                guard let frameDescriptor = self.window?.frameDescriptor else {
+                    return
+                }
+                UserDefaults.standard.setValue(frameDescriptor, forKey: self.name)
+            }
+        }
+    }
+
+    public class Coordinator: NSObject {
+        var parent: FrameAutosaveView
+
+        init(_ parent: FrameAutosaveView) {
+            self.parent = parent
+        }
+
+    }
+
+    let name: String
+
+    public init(_ name: String) {
+        self.name = name
+    }
+
+    public func makeNSView(context: Context) -> FrameAutosaveNSView {
+        return FrameAutosaveNSView(name: "name")
+    }
+
+    public func updateNSView(_ view: FrameAutosaveNSView, context: Context) {
+        view.name = name
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        return Coordinator(self)
+    }
+
+}
+
+struct FrameAutosave: ViewModifier {
+
+    let name: String
+
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            FrameAutosaveView(name)
+                .frame(maxHeight: 0)
+        }
+    }
+}
+
+extension View {
+
+    func frameAutosaveName(_ name: String) -> some View {
+        return self.modifier(FrameAutosave(name: name))
+    }
+
+}


### PR DESCRIPTION
This change works around SwiftUI's inability to autosave the window frame by injecting an NSView into the SwiftUI view heirarchy and using the lifecycle of this view to set the window frame on construction, and store it in the user defaults when the window frame changes. Hopefully SwiftUI gets official support for this in the future.