### PR TITLE
Ensure the touch target doesn't extend beyond the edges of the bookmark cells

### DIFF
--- a/documentation/release-notes/macos.markdown
+++ b/documentation/release-notes/macos.markdown
@@ -4,6 +4,8 @@
 
 Changes on `main` pending release.
 
+- Fix an issue where clicking on a bookmark sometimes opened the wrong link.
+
 ## Version 0.1.2
 
 Approaching feature parity with the initial Catalyst-based macOS build.

--- a/macos/Bookmarks/Views/BookmarkCell.swift
+++ b/macos/Bookmarks/Views/BookmarkCell.swift
@@ -77,6 +77,7 @@ struct BookmarkCell: View {
             .padding()
         }
         .background(Color(NSColor.controlBackgroundColor))
+        .contentShape(Rectangle())
         .cornerRadius(10)
         .onAppear {
             // TODO: Determine the appropriate default size for thumbnails.


### PR DESCRIPTION
The bookmark cells were accepting touches beyond the edges of the views if the images did not perfectly match the aspect ratio and were clipped. This adds an explicit content shape to clip the views interactions.