### PR TITLE
docs: Remove the macOS release note link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 ## Release Notes
 
 - [iOS](documentation/release-notes/ios.markdown)
-- [macOS](documentation/release-notes/macos.markdown)
 
 ## Development
 


### PR DESCRIPTION
The macOS release notes are now out-of-date (after switching to a semantic versioning release model) and might be misleading. Removing them for the time being.