### PR TITLE
ci(macOS): Build Sparkle tools

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -130,6 +130,11 @@ function cleanup {
 
 trap cleanup EXIT
 
+# Build the Sparkle tools to ensure we can generate an appcast.
+pushd "sparkle"
+echo "n" | BUILDDIR=build make release
+popd
+
 # Determine the version and build number.
 VERSION_NUMBER=`"$CHANGES_SCRIPT" --scope macOS current-version`
 GIT_COMMIT=`git rev-parse --short HEAD`


### PR DESCRIPTION
In preparation for generating Sparkle appcasts, we want to make sure we have the appropriate version of the Sparkle tooling available, so we build our submodule.