### PR TITLE
ci: Skip macOS binary notarization on PR builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,9 +30,10 @@ jobs:
         CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY: ${{ secrets.CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY }}
         APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
         FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD: ${{ secrets.FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD }}
-        TRY_RELEASE: ${{ github.ref == 'refs/heads/main' }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: exec ./scripts/build.sh
+        NOTARIZE: ${{ github.ref == 'refs/heads/main' }}
+        TRY_RELEASE: ${{ github.ref == 'refs/heads/main' }}
+      run: scripts/build.sh
 
     - name: Archive the binary
       uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ In order to make continuous integration easy the `scripts/build.sh` script build
 - `CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY` -- a GitHub authorization key used to access the certificate repository (see the [match authorization docs](https://docs.fastlane.tools/actions/match/#git-storage-on-github))
 - `APPLE_DEVELOPER_ID` -- individual Apple Developer Account ID (used for notarization)
 - `FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD` -- [app-specific password](https://support.apple.com/en-us/HT204397) for the Developer Account
+- `NOTARIZE` -- boolean indicating whether to attempt notarize the build (conditionally set based on the current branch using `${{ github.ref == 'refs/heads/main' }}`)
 - `TRY_RELEASE` -- boolean indicating whether to attempt a release (conditionally set based on the current branch using `${{ github.ref == 'refs/heads/main' }}`)
 - `GITHUB_TOKEN` -- [GitHub token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) used to create the release
 
@@ -63,6 +64,12 @@ Once you've added your environment variables to this, run the script from the ro
 
 ```bash
 ./scripts/build.sh
+```
+
+You can notarize local builds by specifying the `--notarize` parameter:
+
+```bash
+./scripts/build.sh --notarize
 ```
 
 You can publish a build locally by specifying the `--release` parameter:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -25,9 +25,9 @@ set -o pipefail
 set -x
 set -u
 
-SCRIPT_DIRECTORYS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+SCRIPTS_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-ROOT_DIRECTORY="${SCRIPT_DIRECTORYS}/.."
+ROOT_DIRECTORY="${SCRIPTS_DIRECTORY}/.."
 BUILD_DIRECTORY="${ROOT_DIRECTORY}/build"
 TEMPORARY_DIRECTORY="${ROOT_DIRECTORY}/temp"
 
@@ -40,14 +40,14 @@ BUILD_TOOLS_SCRIPT="${ROOT_DIRECTORY}/scripts/build-tools/build-tools"
 
 # Process the command line arguments.
 POSITIONAL=()
-NOTARIZE=true
+NOTARIZE=${NOTARIZE:-false}
 RELEASE=false
 while [[ $# -gt 0 ]]
 do
     key="$1"
     case $key in
-        -N|--skip-notarize)
-        NOTARIZE=false
+        -n|--notarize)
+        NOTARIZE=true
         shift
         ;;
         -r|--release)


### PR DESCRIPTION
This includes a drive-by fix to the previous incorrectly renamed `SCRIPTS_DIRECTORY` environment variable. 🤦🏻‍♂️