### PR TITLE
ci: Remove requirement for TRY_RELEASE to be defined for local builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ export FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=
 
 # GitHub (only required if publishing releases locally)
 export GITHUB_TOKEN=
-
-# Release
-export TRY_RELEASE=false
 ```
 
 You can generate your GitHub authorization key (for `CERTIFICATE_REPOSITORY_AUTHORIZATION_KEY`) as follows:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -44,7 +44,7 @@ PATH=$PATH:$BUILD_TOOLS_DIRECTORY
 # Process the command line arguments.
 POSITIONAL=()
 NOTARIZE=${NOTARIZE:-false}
-RELEASE=false
+RELEASE=${TRY_RELEASE:-false}
 while [[ $# -gt 0 ]]
 do
     key="$1"
@@ -195,7 +195,7 @@ zip -r "Artifacts.zip" "."
 popd
 
 # Attempt to create a version tag and publish a GitHub release; fails quietly if there's no new release.
-if $RELEASE || $TRY_RELEASE ; then
+if $RELEASE ; then
     changes \
         --scope macOS \
         release \


### PR DESCRIPTION
Since the build script checks for unbound variables, it failed if `TRY_RELEASE` wasn't specified even though it's unnecessary and can be overriden with the `--release` flag.

This change also includes a drive-by fix to remove a hidden file that was mistakenly checked in.